### PR TITLE
Insert server middleware before RetryJobs

### DIFF
--- a/lib/apartment/sidekiq.rb
+++ b/lib/apartment/sidekiq.rb
@@ -21,7 +21,7 @@ module Apartment
           end
 
           config.server_middleware do |chain|
-            chain.add Apartment::Sidekiq::Middleware::Server
+            chain.insert_before ::Sidekiq::Middleware::Server::RetryJobs, Apartment::Sidekiq::Middleware::Server
           end
         end
       end

--- a/lib/apartment/sidekiq/version.rb
+++ b/lib/apartment/sidekiq/version.rb
@@ -1,5 +1,5 @@
 module Apartment
   module Sidekiq
-    VERSION = "0.2.0"
+    VERSION = "0.2.1"
   end
 end


### PR DESCRIPTION
This PR fixes the issue with ```sidekiq_retries_exhausted``` block not switching tenants.