### PR TITLE
#12 Rails 5.0 incompatibilities Fix

### DIFF
--- a/lib/apartment/sidekiq.rb
+++ b/lib/apartment/sidekiq.rb
@@ -16,10 +16,6 @@ module Apartment
         end
 
         ::Sidekiq.configure_server do |config|
-          config.client_middleware do |chain|
-            chain.add Apartment::Sidekiq::Middleware::Client
-          end
-
           config.server_middleware do |chain|
             chain.add Apartment::Sidekiq::Middleware::Server
           end


### PR DESCRIPTION
**Cause:**
Debugging #12 seems when the client-side middleware is chained in server, `Apartment::Tenant.current` is set to `base` tenant overriding the correct current_tenant stored in `item['apartment']`.

Chaining client-side in both places is mentioned in Sidekiq docs https://github.com/mperham/sidekiq/wiki/Middleware#sometimes-client-side-middleware-should-be-registered-in-both-places but not sure why it's breaking things now in rails 5.

**Fix:**
Removing the server chain fixes this for me _[rails5, mysql, using schema=true]_

**P.S**
Not sure if this has some other side effects and it will require more testing.