### PR TITLE
Sidekiq::Batch compatibility

### DIFF
--- a/lib/apartment/sidekiq.rb
+++ b/lib/apartment/sidekiq.rb
@@ -21,7 +21,11 @@ module Apartment
           end
 
           config.server_middleware do |chain|
-            chain.add Apartment::Sidekiq::Middleware::Server
+            if defined?(::Sidekiq::Batch::Server)
+              chain.insert_before Sidekiq::Batch::Server, Apartment::Sidekiq::Middleware::Server
+            else
+              chain.add Apartment::Sidekiq::Middleware::Server
+            end
           end
         end
       end


### PR DESCRIPTION
Several Sidekiq Pro customers using apartment-sidekiq have contacted me with a mysterious problem: their batch jobs ran fine with the expected apartment tenant but the batch callbacks did not use the same tenant as expected.  This turned out to be a middleware ordering issue: apartment's server middleware needs to come before the batch server middleware.  This PR ensures compatibility.

I also added a note to your wiki about the same.