### PR TITLE
Allow the gem to depend on apartment version 2.0

### DIFF
--- a/apartment-sidekiq.gemspec
+++ b/apartment-sidekiq.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
   spec.add_development_dependency 'minitest'
 
-  spec.add_dependency 'apartment', '~> 1.0'
+  spec.add_dependency 'apartment', '~> 1.0', '~> 2.0'
   spec.add_dependency 'sidekiq', '>= 2.11'
 end


### PR DESCRIPTION
This updates the gemspec to also support version 2.0 of the apartment gem as a dependency.

I decided to use a compound requirement with each version specified on it's own instead of doing something more permissive such as saying any version under 3.0 or removing the dependency entirely.

Resolves #18