### PR TITLE
Allow Apartment v2, fix Sidekiq Pro Batch Lookup

### DIFF
--- a/apartment-sidekiq.gemspec
+++ b/apartment-sidekiq.gemspec
@@ -18,10 +18,10 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.3"
+  spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake"
   spec.add_development_dependency 'minitest'
 
-  spec.add_dependency 'apartment', '~> 1.0'
+  spec.add_dependency 'apartment', '>= 1.0'
   spec.add_dependency 'sidekiq', '>= 2.11'
 end

--- a/lib/apartment/sidekiq.rb
+++ b/lib/apartment/sidekiq.rb
@@ -11,20 +11,20 @@ module Apartment
       def self.run
         ::Sidekiq.configure_client do |config|
           config.client_middleware do |chain|
-            chain.add Apartment::Sidekiq::Middleware::Client
+            chain.add ::Apartment::Sidekiq::Middleware::Client
           end
         end
 
         ::Sidekiq.configure_server do |config|
           config.client_middleware do |chain|
-            chain.add Apartment::Sidekiq::Middleware::Client
+            chain.add ::Apartment::Sidekiq::Middleware::Client
           end
 
           config.server_middleware do |chain|
             if defined?(::Sidekiq::Batch::Server)
-              chain.insert_before Sidekiq::Batch::Server, Apartment::Sidekiq::Middleware::Server
+              chain.insert_before ::Sidekiq::Batch::Server, ::Apartment::Sidekiq::Middleware::Server
             else
-              chain.add Apartment::Sidekiq::Middleware::Server
+              chain.add ::Apartment::Sidekiq::Middleware::Server
             end
           end
         end


### PR DESCRIPTION
I know this is already done in two separate MR but I also needed the fix for Sidekiq Pro. @mperham fix this but didn't correctly reference `::Sidekiq::Batch::Server` in the `insert_before` method. This prevented us from starting sidekiq server 